### PR TITLE
Add support for gzip response decompression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ node_modules
 # Optional REPL history
 .node_repl_history
 
+# JetBrains IDEs
+/.idea/
+
 dist
 bower_components
 config.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tibber-httpclient",
-  "version": "1.13.9",
+  "version": "1.13.11",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tibber-httpclient",
-  "version": "1.13.8",
+  "version": "1.13.9",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,15 +13,15 @@ export interface Cache {
     set<T>(key: string, payload: T): void;
 }
 
-export type ClientOptions = Pick<CoreOptions, "timeout" | "gzip">;
+export type RequestOptions = Pick<CoreOptions, "timeout" | "gzip">;
 
 export interface IHttpClient {
 
-    get<T>(route: string, options?: ClientOptions): Promise<T>;
-    post<T>(route: string, payload?: object, options?: ClientOptions): Promise<T>;
-    patch<T>(route: string, payload?: object, options?: ClientOptions): Promise<T>;
-    put<T>(route: string, payload: object, options?: ClientOptions): Promise<T>;
-    delete(route: string, options?: ClientOptions);
+    get<T>(route: string, options?: RequestOptions): Promise<T>;
+    post<T>(route: string, payload?: object, options?: RequestOptions): Promise<T>;
+    patch<T>(route: string, payload?: object, options?: RequestOptions): Promise<T>;
+    put<T>(route: string, payload: object, options?: RequestOptions): Promise<T>;
+    delete(route: string, options?: RequestOptions);
 }
 
 export interface ICachedHttpClient extends IHttpClient {
@@ -73,7 +73,7 @@ export class HttpClient implements IHttpClient {
         this._defaultHeaders = defaultHeaders ? Object.assign(this._defaultHeaders || {}, defaultHeaders) : this._defaultHeaders;
     }
 
-    private async _request(method: HTTP_METHOD, path: string, body?: object, clientOptions: ClientOptions = {}) {
+    private async _request(method: HTTP_METHOD, path: string, body?: object, requestOptions: RequestOptions = {}) {
 
         const url = `${this._baseUrl}${path}`;
         const start = moment();
@@ -85,7 +85,7 @@ export class HttpClient implements IHttpClient {
             headers: this._defaultHeaders,
             resolveWithFullResponse: true,
             json: true,
-            ...clientOptions,
+            ...requestOptions,
         };
         try {
             const result = await request(options);
@@ -112,23 +112,23 @@ export class HttpClient implements IHttpClient {
         }
     }
 
-    public async get<T>(route: string, options?: ClientOptions): Promise<T> {
+    public async get<T>(route: string, options?: RequestOptions): Promise<T> {
         return await this._request("GET", route, undefined, options);
     }
 
-    public async post<T>(route: string, payload?: object, options?: ClientOptions): Promise<T> {
+    public async post<T>(route: string, payload?: object, options?: RequestOptions): Promise<T> {
         return await this._request("POST", route, payload, options);
     }
 
-    public async patch<T>(route: string, payload?: object, options?: ClientOptions): Promise<T> {
+    public async patch<T>(route: string, payload?: object, options?: RequestOptions): Promise<T> {
         return (await this._request("PATCH", route, payload, options));
     }
 
-    public async put<T>(route: string, payload: object, options?: ClientOptions): Promise<T> {
+    public async put<T>(route: string, payload: object, options?: RequestOptions): Promise<T> {
         return await this._request("PUT", route, payload, options);
     }
 
-    public async delete(route: string, options?: ClientOptions) {
+    public async delete(route: string, options?: RequestOptions) {
         return await this._request("DELETE", route, undefined, options);
     }
 }


### PR DESCRIPTION
Tibber.IoT's endpoint for fetching hourly Pulse history data streams GZip compressed JSON blobs directly from S3, which means that this HTTP client library needs to support GZip compression (honestly a bit surprised that response compression appears not to be that pervasive).

Since this is a per-request thing, I chose not to extend the client constructor options because it wouldn't make a lot of sense.

It got a bit messy with multiple optional parameters, so I elected to introduce a partial `RequestOptions` type.

NOTE: This does introduce a breaking change, but according to @gvaartjes it's OK since the addition of the `timeout` parameter was a very recent addition to quickly solve a platform issue.
